### PR TITLE
travis: change to new Bintray organization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 addons:
   apt:
     sources:
-     - sourceline: 'deb https://dl.bintray.com/sb-backup/travis-deps trusty main'
+     - sourceline: 'deb https://dl.bintray.com/gob-backup/travis-deps trusty main'
     packages:
      - libsodium23
      - libsodium-dev


### PR DESCRIPTION
Due to the rename to "gob", the organization name on Bintray has changed
from "sb-backup" to "gob-backup". Update the Travis configuration
accordingly.