### PR TITLE
travis: provide key URL for Bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
   apt:
     sources:
      - sourceline: 'deb https://dl.bintray.com/gob-backup/travis-deps trusty main'
+       key_url: 'https://bintray.com/user/downloadSubjectPublicKey?username=bintray'
     packages:
      - libsodium23
      - libsodium-dev


### PR DESCRIPTION
Due to a recently reported MITM RCE via Travis' APT package integration,
the build service has changed the default invocation of apt to not use
'--force-yes'. This causes our builds to fail, as we require packages
hosted via Bintray which are not signed by keys which are part of the
official Trusty distribution. As we do not force-install them anymore,
installing these packages will now fail.

Fix the issue by providing Bintray's key to the APT addon.