### PR TITLE
gob-fsck: add missing <stdlib.h> include for malloc/free

### DIFF
--- a/gob-fsck.c
+++ b/gob-fsck.c
@@ -20,6 +20,7 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Same as in commit f37c1e9 (gob-chunk: add missing <stdlib.h> include for
malloc/free, 2018-12-12), gob-fsck.c is missing the include <stdlib.h>
for both definitions of malloc(3) and free(3). Add it to fix build
warnings.