### PR TITLE
common: implement error checking for stdout

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -44,6 +44,8 @@ void die_errno(const char *fmt, ...);
 void warn(const char *fmt, ...);
 void version(const char *executable);
 
+void close_stdout(void);
+
 ssize_t read_bytes(int fd, unsigned char *buf, size_t buflen);
 int write_bytes(int fd, const unsigned char *buf, size_t buflen);
 

--- a/src/gob-cat.c
+++ b/src/gob-cat.c
@@ -64,6 +64,8 @@ int main(int argc, char *argv[])
     if (argc != 2)
         die("USAGE: %s ( --version | <DIR> )", argv[0]);
 
+    atexit(close_stdout);
+
     if (!strcmp(argv[1], "--version"))
         version("gob-cat");
 

--- a/src/gob-chunk.c
+++ b/src/gob-chunk.c
@@ -42,6 +42,8 @@ int main(int argc, char *argv[])
     if (argc != 2)
         die("USAGE: %s ( --version | <DIR> )", argv[0]);
 
+    atexit(close_stdout);
+
     if (!strcmp(argv[1], "--version"))
         version("gob-chunk");
 

--- a/src/gob-fsck.c
+++ b/src/gob-fsck.c
@@ -134,6 +134,8 @@ int main(int argc, char *argv[])
     if (argc != 2)
         die("USAGE: %s ( --version | <DIR> )", argv[0]);
 
+    atexit(close_stdout);
+
     if (!strcmp(argv[1], "--version"))
         version("gob-fsck");
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,5 @@
+cc = meson.get_compiler('c')
+
 args = [
   '-Wall', '-Wextra', '-pedantic', '-Wno-long-long',
   '-D_BSD_SOURCE', '-D_POSIX_C_SOURCE=200809L', '-DGOB_VERSION="@0@"'.format(meson.project_version())
@@ -5,6 +7,10 @@ args = [
 foreach arg : args
   add_project_arguments(arg, language: 'c')
 endforeach
+
+if cc.has_function('__fpending')
+  add_project_arguments('-DHAVE_FPENDING', language: 'c')
+endif
 
 executable(
   'gob-cat',


### PR DESCRIPTION
When writing to stdout fails gob will not notice this right now, leading
to potential loss of e.g. the list of chunks stored by gob-chunk(1).
Introduce a new function `close_stdout` taken from gnulib that is being
executed at exit that checks the standard streams for errors and closes
them. If any error occurs or has occurred with stdout, then it will
print an error message and return an error code.