### PR TITLE
travis: raise warnlevel and enable -Werror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
 
 script:
   - mkdir build
-  - meson build . --prefix="${HOME}/dest"
+  - meson build . --prefix="${HOME}/dest" --warnlevel 3 --werror
   - ninja -C build test install
 
 branches:

--- a/src/common.c
+++ b/src/common.c
@@ -59,8 +59,6 @@ void warn(const char *fmt, ...)
     vfprintf(stderr, fmt, ap);
     va_end(ap);
     putc('\n', stderr);
-
-    exit(1);
 }
 
 void version(const char *executable)

--- a/src/common.c
+++ b/src/common.c
@@ -343,7 +343,7 @@ out:
     return 0;
 }
 
-int store_read(unsigned char *out, size_t outlen, struct store *store, const struct hash *hash)
+ssize_t store_read(unsigned char *out, size_t outlen, struct store *store, const struct hash *hash)
 {
     int fd, shardfd;
     ssize_t len;

--- a/src/common.c
+++ b/src/common.c
@@ -128,14 +128,14 @@ static char to_hex[] = "0123456789abcdef";
 int hash_from_bin(struct hash *out, const unsigned char *data, size_t len)
 {
     size_t i;
-    char *p;
+    char *p = &out->hex[0];
 
     if (len != HASH_LEN)
         return -1;
 
     memcpy(&out->bin[0], data, len);
 
-    for (p = &out->hex[0], i = 0; i < HASH_LEN; i++) {
+    for (i = 0; i < HASH_LEN; i++) {
         *p++ = to_hex[((unsigned int) out->bin[i]) >> 4];
         *p++ = to_hex[((unsigned int) out->bin[i]) & 0xf];
     }

--- a/src/common.c
+++ b/src/common.c
@@ -101,10 +101,10 @@ ssize_t read_bytes(int fd, unsigned char *buf, size_t buflen)
             return -1;
         if (bytes == 0)
             break;
-        total += bytes;
+        total += (size_t) bytes;
     }
 
-    return total;
+    return (ssize_t) total;
 }
 
 int write_bytes(int fd, const unsigned char *buf, size_t buflen)
@@ -117,7 +117,7 @@ int write_bytes(int fd, const unsigned char *buf, size_t buflen)
             continue;
         if (bytes <= 0)
             return -1;
-        total += bytes;
+        total += (size_t) bytes;
     }
 
     return 0;

--- a/src/common.h
+++ b/src/common.h
@@ -65,4 +65,4 @@ int hash_state_final(struct hash *out, struct hash_state *state);
 int store_open(struct store *out, const char *path);
 void store_close(struct store *store);
 int store_write(struct hash *out, struct store *store, const unsigned char *data, size_t datalen);
-int store_read(unsigned char *out, size_t outlen, struct store *store, const struct hash *hash);
+ssize_t store_read(unsigned char *out, size_t outlen, struct store *store, const struct hash *hash);

--- a/src/common.h
+++ b/src/common.h
@@ -43,10 +43,10 @@ struct store {
     int shardfds[256];
 };
 
-void die(const char *fmt, ...);
-void die_errno(const char *fmt, ...);
-void warn(const char *fmt, ...);
-void version(const char *executable);
+void die(const char *fmt, ...) __attribute__((noreturn, format(printf, 1, 2)));
+void die_errno(const char *fmt, ...) __attribute__((noreturn, format(printf, 1, 2)));
+void warn(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void version(const char *executable) __attribute__((noreturn));
 
 void close_stdout(void);
 

--- a/src/gob-cat.c
+++ b/src/gob-cat.c
@@ -38,7 +38,7 @@ static int parse_trailer(struct hash *hash_out, size_t *datalen_out, const char 
         die("No separator between trailer hash and length");
     trailer++;
 
-    if ((*datalen_out = strtol(trailer, NULL, 10)) == 0)
+    if ((*datalen_out = strtoul(trailer, NULL, 10)) == 0)
         die("Invalid data length in trailer");
 
     return 0;
@@ -78,19 +78,19 @@ int main(int argc, char *argv[])
         if (line[linelen - 1] == '\n')
             line[--linelen] = '\0';
 
-        if (hash_from_str(&hash, line, linelen) < 0)
+        if (hash_from_str(&hash, line, (size_t) linelen) < 0)
             die("Invalid index hash '%s'", line);
 
         if ((blocklen = store_read(block, BLOCK_LEN, &store, &hash)) < 0)
             die_errno("Unable to open block '%s'", line);
 
-        if (hash_state_update(&state, block, blocklen) < 0)
+        if (hash_state_update(&state, block, (size_t) blocklen) < 0)
             die("Unable to update hash");
 
-        if (write_bytes(STDOUT_FILENO, block, blocklen) < 0)
+        if (write_bytes(STDOUT_FILENO, block, (size_t) blocklen) < 0)
             die_errno("Unable to write block '%s'", line);
 
-        total += blocklen;
+        total += (size_t) blocklen;
     }
 
     if (linelen < 0 && !feof(stdin))

--- a/src/gob-chunk.c
+++ b/src/gob-chunk.c
@@ -48,11 +48,11 @@ int main(int argc, char *argv[])
     while ((bytes = read_bytes(STDIN_FILENO, block, BLOCK_LEN)) > 0) {
         struct hash hash;
 
-        total += bytes;
+        total += (size_t) bytes;
 
-        if (hash_state_update(&state, block, bytes) < 0)
+        if (hash_state_update(&state, block, (size_t) bytes) < 0)
             die("Unable to update hash");
-        if (store_write(&hash, &store, block, bytes) < 0)
+        if (store_write(&hash, &store, block, (size_t) bytes) < 0)
             die("Unable to store block");
         puts(hash.hex);
     }

--- a/src/gob-chunk.c
+++ b/src/gob-chunk.c
@@ -46,8 +46,6 @@ int main(int argc, char *argv[])
         die("Unable to initialize hashing state");
 
     while ((bytes = read_bytes(STDIN_FILENO, block, BLOCK_LEN)) > 0) {
-        struct hash hash;
-
         total += (size_t) bytes;
 
         if (hash_state_update(&state, block, (size_t) bytes) < 0)

--- a/src/gob-fsck.c
+++ b/src/gob-fsck.c
@@ -67,7 +67,7 @@ static int scan_shard(int storefd, const char *shard)
 
         if (strlen(ent->d_name) != (HASH_LEN * 2 - 2) ||
                 strspn(ent->d_name, HEXCHARS) != (HASH_LEN * 2 - 2)) {
-            warn("invalid entry name '%s/%s' %lu %lu", shard, ent->d_name, strspn(ent->d_name, HEXCHARS), HASH_LEN * 2 - 2);
+            warn("invalid entry name '%s/%s' %lu %d", shard, ent->d_name, strspn(ent->d_name, HEXCHARS), HASH_LEN * 2 - 2);
             err = -1;
             goto next;
         }

--- a/src/gob-fsck.c
+++ b/src/gob-fsck.c
@@ -47,8 +47,9 @@ static int scan_shard(int storefd, const char *shard)
     }
 
     while ((ent = readdir(sharddir)) != NULL) {
-        int bytes, blockfd = -1;
         struct stat stat;
+        int blockfd = -1;
+        ssize_t bytes;
 
         if (!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, ".."))
             continue;
@@ -84,7 +85,7 @@ static int scan_shard(int storefd, const char *shard)
             goto next;
         }
 
-        if (hash_compute(&computed_hash, block, bytes) < 0) {
+        if (hash_compute(&computed_hash, block, (size_t) bytes) < 0) {
             warn("Unable to hash block");
             err = -1;
             goto next;

--- a/src/gob-fsck.c
+++ b/src/gob-fsck.c
@@ -156,7 +156,7 @@ int main(int argc, char *argv[])
         }
 
         if (!S_ISDIR(stat.st_mode)) {
-            warn("invalid entry '%s/%s'", argv[1], ent->d_name);
+            warn("invalid shard '%s/%s'", argv[1], ent->d_name);
             err = -1;
             continue;
         }

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,6 +3,7 @@ cc = meson.get_compiler('c')
 args = [
     '-Wno-long-long',
     '-Wno-padded',
+    '-Wno-disabled-macro-expansion',
     '-D_BSD_SOURCE',
     '-D_POSIX_C_SOURCE=200809L',
 ]

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,7 +4,6 @@ args = [
     '-Wno-long-long',
     '-Wno-padded',
     '-Wno-disabled-macro-expansion',
-    '-D_BSD_SOURCE',
     '-D_POSIX_C_SOURCE=200809L',
 ]
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,6 +2,7 @@ cc = meson.get_compiler('c')
 
 args = [
     '-Wno-long-long',
+    '-Wno-padded',
     '-D_BSD_SOURCE',
     '-D_POSIX_C_SOURCE=200809L',
 ]

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -28,7 +28,7 @@ assert_success() {
 
 assert_failure() {
 	eval "$@"
-	test $? -eq 1
+	test $? -ne 0
 }
 
 test_expect_success() {
@@ -174,7 +174,7 @@ test_expect_success 'fsck with valid block store succeeds' '
 	assert_success gob-fsck fsck
 '
 
-test_expect_success 'fsck with invalid store file fails' '
+test_expect_success 'fsck with invalid shard fails' '
 	assert_success gob-fsck fsck &&
 	assert_success touch fsck/bogus &&
 	assert_failure gob-fsck fsck &&


### PR DESCRIPTION
To be able to detect more warnings across different toolchains, raise
the warnlevel to 3. Also enable -Werror to let builds fail if any
warnings exist.