### PR TITLE
gob-init: implement command to initialize stores

### DIFF
--- a/docs/gob-init.1
+++ b/docs/gob-init.1
@@ -1,0 +1,13 @@
+.TH GOB-INIT  "1"
+.SH NAME
+gob-init \- Initialire a new blob store
+.SH SYNOPSIS
+.B gob-init <BLOCKSTORAGE>
+.SH DESCRIPTION
+gob-init creates a new blob store at the given target path.
+The target path may not exist yet.
+.SH OPTIONS
+<BLOCKSTORAGE>
+.RS 4
+Path to the new block storage.
+.RE

--- a/src/common.h
+++ b/src/common.h
@@ -46,6 +46,7 @@ struct store {
 int gob_cat(int argc, const char *argv[]);
 int gob_chunk(int argc, const char *argv[]);
 int gob_fsck(int argc, const char *argv[]);
+int gob_init(int argc, const char *argv[]);
 
 void die(const char *fmt, ...) __attribute__((noreturn, format(printf, 1, 2)));
 void die_errno(const char *fmt, ...) __attribute__((noreturn, format(printf, 1, 2)));
@@ -65,6 +66,7 @@ int hash_state_init(struct hash_state *state);
 int hash_state_update(struct hash_state *state, const unsigned char *data, size_t len);
 int hash_state_final(struct hash *out, struct hash_state *state);
 
+int store_init(const char *path);
 int store_open(struct store *out, const char *path);
 void store_close(struct store *store);
 int store_write(struct hash *out, struct store *store, const unsigned char *data, size_t datalen);

--- a/src/gob.c
+++ b/src/gob.c
@@ -27,6 +27,7 @@ static struct {
     { gob_cat,   "cat",   "Concatenate chunks" },
     { gob_chunk, "chunk", "Chunk and store data" },
     { gob_fsck,  "fsck",  "Check consistency of a store"  },
+    { gob_init,  "init",  "Initialize a new store"  },
 };
 
 int main(int argc, const char *argv[])

--- a/src/init.c
+++ b/src/init.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2019 Patrick Steinhardt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common.h"
+
+int gob_init(int argc, const char *argv[])
+{
+    if (argc != 2)
+        die("USAGE: %s init <DIR>", argv[0]);
+
+    atexit(close_stdout);
+
+    if (store_init(argv[1]) < 0)
+        die("Unable to initialize store");
+
+    return 0;
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -29,6 +29,7 @@ executable(
       'chunk.c',
       'common.c',
       'fsck.c',
+      'init.c',
       'blake2/blake2b-ref.c',
       config
   ],

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -37,7 +37,7 @@ test_when_finished() {
 
 test_store() {
 	test_when_finished rm -rvf "$1" &&
-	mkdir "$1"
+	gob init "$1"
 }
 
 test_expect_success() {
@@ -87,6 +87,18 @@ test_expect_success() {
 	fi
 }
 
+test_expect_success 'initializing succeeds' '
+	test_when_finished rm -rf store &&
+	assert_success gob init store &&
+	assert_success test -f store/version
+'
+
+test_expect_success 'initializing fails if target exists' '
+	test_when_finished rm -rf store &&
+	assert_success gob init store &&
+	assert_failure gob init store
+'
+
 test_expect_success 'chunking with invalid block store version fails' '
 	test_store store &&
 	assert_success echo 0 >store/version &&
@@ -100,6 +112,12 @@ test_expect_success 'chunking without block directory fails' '
 
 test_expect_success 'chunking with nonexisting block directory fails' '
 	assert_failure gob chunk foobar
+'
+
+test_expect_success 'chunking fails if target is no blob store' '
+	test_when_finished rm -rf store &&
+	assert_success mkdir store &&
+	assert_failure gob chunk store
 '
 
 test_expect_success 'test -w /dev/full' 'chunking with invalid stdout fails' '


### PR DESCRIPTION
Currently, a blob store is automatically being created whenever
`store_open()` is called with a non-existing target path. Thus, if
calling e.g. git-chunk(1) with a non-existing directory, the command
would have just created the target and pretended everything to be fine.
This is a bit problematic and may hide errors like the wrong path being
passed to git-chunk(1). Even more problematic is that gob-fsck(1) would
create the target directory if it didn't exist.

Remove automatic creation of blob stores to fix this. Create a new
command gob-init(1) that sets up a repo and seeds its "version" file.